### PR TITLE
Ajusta listeners de arrastre según modo

### DIFF
--- a/orugaV3.html
+++ b/orugaV3.html
@@ -423,15 +423,19 @@
 
     // ===== Drag mode / magnet =====
     UI.board.addEventListener('pointerdown', (e)=>{
+      if(state.mode!=='drag') return;
       if(e.pointerType==='mouse' && e.button!==0) return;
       state.dragging = true; UI.board.setPointerCapture?.(e.pointerId);
       armIdle();
       checkMagnet(e);
     });
     UI.board.addEventListener('pointermove', (e)=>{
-      if(!state.dragging) return; checkMagnet(e);
+      if(state.mode!=='drag' || !state.dragging) return;
+      checkMagnet(e);
     });
-    UI.board.addEventListener('pointerup', ()=>{ state.dragging=false });
+    UI.board.addEventListener('pointerup', ()=>{
+      if(state.dragging) state.dragging=false;
+    });
 
     function checkMagnet(e){
       if(state.mode!=='drag') return;


### PR DESCRIPTION
## Summary
- evita iniciar arrastres en el tablero cuando el modo activo no es drag
- condiciona los eventos move y up a que el arrastre esté activo antes de usar la lógica de imán

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cbe4f0b9708322a63911aadf352d58