### PR TITLE
Adjust layout flex behavior for board

### DIFF
--- a/orugaV3.html
+++ b/orugaV3.html
@@ -20,7 +20,15 @@
     }
     *{box-sizing:border-box; -webkit-tap-highlight-color: transparent;}
     html,body{height:100%}
-    body{margin:0;background:radial-gradient(1200px 700px at 10% -20%, #1e293b 0%, #0b1325 60%, #060914 100%);color:var(--ink);font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif}
+    body{
+      margin:0;
+      min-height:100vh;
+      display:flex;
+      flex-direction:column;
+      background:radial-gradient(1200px 700px at 10% -20%, #1e293b 0%, #0b1325 60%, #060914 100%);
+      color:var(--ink);
+      font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif;
+    }
 
     /* ====== Top bar ====== */
     .topbar{display:flex;align-items:center;justify-content:space-between;gap:8px;padding:10px 14px;border-bottom:1px solid #1f2937;background:linear-gradient(#0b1222dd,#0b1222bb);backdrop-filter:saturate(1.2) blur(6px);position:sticky;top:0;z-index:5}
@@ -42,8 +50,19 @@
     #timerbar{height:100%;width:0;background:linear-gradient(90deg,var(--accent),var(--accent-2));transition:width .2s linear}
 
     /* ====== Board ====== */
-    #boardWrap{display:grid;place-items:center;padding:12px}
-    #board{position:relative;width:min(94vw,680px);height:min(120vw,70vh);border-radius:22px;background:radial-gradient(320px 260px at 70% 20%, #0b1427, #0b1222 60%);box-shadow:var(--shadow);touch-action:none;overflow:hidden}
+    #boardWrap{
+      --safe-pad:clamp(12px,4vw,48px);
+      flex:1;
+      display:grid;
+      place-items:center;
+      min-height:0;
+      padding:var(--safe-pad);
+      padding-top:max(var(--safe-pad), env(safe-area-inset-top, 0px));
+      padding-right:max(var(--safe-pad), env(safe-area-inset-right, 0px));
+      padding-bottom:max(var(--safe-pad), env(safe-area-inset-bottom, 0px));
+      padding-left:max(var(--safe-pad), env(safe-area-inset-left, 0px));
+    }
+    #board{position:relative;width:100%;height:100%;border-radius:22px;background:radial-gradient(320px 260px at 70% 20%, #0b1427, #0b1222 60%);box-shadow:var(--shadow);touch-action:none;overflow:hidden}
     svg#wires{position:absolute;inset:0;pointer-events:none}
     #path{fill:none;stroke:var(--good);stroke-width:6;stroke-linejoin:round;stroke-linecap:round;filter:drop-shadow(0 1px 2px #0008)}
     #ghost{fill:none;stroke-dasharray:8 10;stroke:var(--accent);stroke-width:4;opacity:.4}
@@ -79,6 +98,10 @@
     @media (min-width:800px){
       .kid-controls button{min-height:52px;font-size:22px}
       .node{width:62px;height:62px}
+    }
+
+    @media (min-width:1200px) and (min-height:900px){
+      #board{max-width:960px;max-height:760px}
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- make the page body a vertical flex container so the board area can expand
- update the board wrapper padding to respect safe areas while growing with flex
- let the board fill the available space and add a large-screen max size guard

## Testing
- not run (static changes)


------
https://chatgpt.com/codex/tasks/task_e_68cbe8b33680832292d239d161c5d424