### PR TITLE
Adjust node typography sizing

### DIFF
--- a/orugaV3.html
+++ b/orugaV3.html
@@ -67,7 +67,7 @@
     #path{fill:none;stroke:var(--good);stroke-width:6;stroke-linejoin:round;stroke-linecap:round;filter:drop-shadow(0 1px 2px #0008)}
     #ghost{fill:none;stroke-dasharray:8 10;stroke:var(--accent);stroke-width:4;opacity:.4}
 
-    .node{position:absolute;display:grid;place-items:center;width:56px;height:56px;border-radius:999px;background:radial-gradient(circle at 30% 25%, #253049, #0e172a);border:2px solid var(--node-ring);color:#e2e8f0;font-weight:800;letter-spacing:.5px;text-shadow:0 1px 0 #0006;user-select:none;box-shadow:var(--shadow)}
+    .node{position:absolute;display:grid;place-items:center;width:56px;height:56px;border-radius:999px;background:radial-gradient(circle at 30% 25%, #253049, #0e172a);border:2px solid var(--node-ring);color:#e2e8f0;font-weight:800;letter-spacing:.5px;text-shadow:0 1px 0 #0006;user-select:none;box-shadow:var(--shadow);font-size:26px;line-height:1}
     .node[data-state="next"]{border-color:transparent;box-shadow:0 0 0 4px #0008, 0 0 0 8px rgba(34,211,238,.5), 0 0 24px 8px rgba(167,139,250,.35)}
     .node[data-state="next"]::after{content:"";position:absolute;inset:-10px;border-radius:inherit;border:3px dashed rgba(34,211,238,.5);animation:spin 3.2s linear infinite}
     @keyframes spin{to{transform:rotate(360deg)}}
@@ -97,7 +97,7 @@
 
     @media (min-width:800px){
       .kid-controls button{min-height:52px;font-size:22px}
-      .node{width:62px;height:62px}
+      .node{width:70px;height:70px;font-size:30px}
     }
 
     @media (min-width:1200px) and (min-height:900px){


### PR DESCRIPTION
## Summary
- add explicit font sizing and line height to node circle styling
- scale node size and typography further on large screens via media query adjustments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbe943d75c8322b7593583d27977ca